### PR TITLE
Removal of FIGI link under Useful Links

### DIFF
--- a/pages/Useful Links.md
+++ b/pages/Useful Links.md
@@ -115,10 +115,6 @@ view the&nbsp;Group Personal Accident (GPA) Product factsheet</p>
 </p>
 </li>
 <li>
-<p><a href="http://w1121padmw01663.schools.moe.edu.sg/figi/" rel="noopener noreferrer nofollow" target="_blank">FIGI</a>
-</p>
-</li>
-<li>
 <p><a href="https://sites.google.com/view/hpps-ict/" rel="noopener noreferrer nofollow" target="_blank">HPPS ICT Website</a>
 </p>
 </li>


### PR DESCRIPTION
Removed FIGI link under Useful Links, as no longer required.